### PR TITLE
Add configuration support

### DIFF
--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,4 +1,7 @@
 {
-  "workspace.color": 0,
-  "workspace.name": "nova/yaml"
+  "workspace.color" : 0,
+  "workspace.name" : "yaml",
+  "yaml.customTags" : [
+    "!secret scalar"
+  ]
 }

--- a/examples/custom-tags.yml
+++ b/examples/custom-tags.yml
@@ -1,0 +1,1 @@
+password: !secret something

--- a/src/Scripts/main.ts
+++ b/src/Scripts/main.ts
@@ -1,9 +1,9 @@
 //
-// Extension entrypoint
+// Extension entry point
 //
 
 import { dependencyManagement } from "nova-extension-utils";
-import { execute, readJson, writeJson } from "./utils";
+import { execute } from "./utils";
 
 // Toggle on in development to --inspect the language server
 const DEBUG_INSPECT = false;
@@ -38,73 +38,6 @@ async function reload() {
   await activate();
 }
 
-interface SchemaStoreCatalog {
-  schemas: Array<{
-    name: string;
-    description: string;
-    fileMatch: string[];
-    url: string;
-  }>;
-}
-
-/**
- * Not in use.
- * Fetch the schema catalog using fetch and cache it into extension storage
- */
-async function fetchAndCacheSchemaCatalog(
-  noCache = false
-): Promise<SchemaStoreCatalog> {
-  const cachePath = nova.path.join(
-    nova.extension.globalStoragePath,
-    "catalog.json"
-  );
-
-  // If the cached file exists, read, decode and return the cached value
-  // let catalog: SchemaStoreCatalog = undefined;
-  if (!noCache && nova.fs.access(cachePath, nova.fs.F_OK)) {
-    debug("Reading catalog.json from storage");
-    const fromCache = readJson(cachePath);
-    if (fromCache) return fromCache;
-
-    debug("Catalog cache not found or unreadable");
-  }
-
-  // Fetch schemas from the schemastore using the fetch API
-  debug("Fetching catalog.json from schemastore.org");
-  const catalog: SchemaStoreCatalog = await fetch(
-    "https://www.schemastore.org/api/json/catalog.json"
-  ).then((r: any) => r.json());
-
-  // If the cache file exists, remove it now
-  if (nova.fs.access(cachePath, nova.fs.F_OK)) {
-    debug("Removing catalog.json from storage");
-    nova.fs.remove(cachePath);
-  }
-
-  // Cache the network response
-  debug("Caching catalog.json into extension storage");
-  writeJson(cachePath, catalog);
-
-  // Return the catalog
-  return catalog;
-}
-
-/**
- * Not in use. The yaml-language-server does this by default and as a first version of the extension, its simpler to use that for now.
- * It should use the same underlying fetch api under the hood.
- */
-async function fetchSchemaAssociations(): Promise<any> {
-  const catalog = await fetchAndCacheSchemaCatalog();
-
-  const result = catalog.schemas.map((item) => ({
-    uri: item.url,
-    fileMatch: item.fileMatch,
-  }));
-
-  // Return the map of schemas
-  return result;
-}
-
 type ServerOptions = ConstructorParameters<typeof LanguageClient>[2];
 type ClientOptions = ConstructorParameters<typeof LanguageClient>[3];
 
@@ -117,6 +50,42 @@ async function findNodeJsPath(): Promise<string | null> {
     args: ["which", "node"],
   });
   return status === 0 ? stdout.trim() : null;
+}
+
+function generateKubernetesPaths(): string[] {
+  const keywords = [
+    "deployment",
+    "deploy",
+    "configmap",
+    "cm",
+    "namespace",
+    "ns",
+    "persistentvolumeclaim",
+    "pvc",
+    "pod",
+    "po",
+    "secret",
+    "service",
+    "svc",
+    "serviceaccount",
+    "sa",
+    "daemonset",
+    "ds",
+    "cronjob",
+    "cj",
+    "job",
+    "ingress",
+    "ing",
+  ];
+
+  const k8sFiles: string[] = [];
+
+  for (const keyword of keywords) {
+    k8sFiles.push(`**/*${keyword}.yml`);
+    k8sFiles.push(`**/*${keyword}.yaml`);
+  }
+
+  return k8sFiles;
 }
 
 /**
@@ -169,56 +138,12 @@ export async function activate() {
       serverOptions.args!.unshift("--inspect-brk=9231", "--trace-warnings");
     }
 
-    const keywords = [
-      "deployment",
-      "deploy",
-      "configmap",
-      "cm",
-      "namespace",
-      "ns",
-      "persistentvolumeclaim",
-      "pvc",
-      "pod",
-      "po",
-      "secret",
-      "service",
-      "svc",
-      "serviceaccount",
-      "sa",
-      "daemonset",
-      "ds",
-      "cronjob",
-      "cj",
-      "job",
-      "ingress",
-      "ing",
-    ];
-    const k8sFiles: string[] = [];
-
-    for (const keyword of keywords) {
-      k8sFiles.push(`**/*${keyword}.yml`);
-      k8sFiles.push(`**/*${keyword}.yaml`);
-    }
-
-    // Settings to configure the yaml language server
-    const settings = {
-      yaml: {
-        format: {
-          enable: false,
-        },
-        validate: true,
-        hover: true,
-        completion: true,
-        schemas: {
-          kubernetes: k8sFiles,
-        },
-        schemaStore: { enable: true },
-      },
+    const customSchemas: Record<string, string[]> = {
+      kubernetes: generateKubernetesPaths(),
     };
 
     const clientOptions: ClientOptions = {
       syntaxes: ["yaml"],
-      initializationOptions: settings,
     };
 
     // Create our LanguageClient and start it
@@ -237,12 +162,18 @@ export async function activate() {
       console.error("LSP stopped", err);
     });
 
-    // Initially setup the workspace
-    // -> Needed to trigger yaml-language-server internals
-    client.sendNotification("workspace/didChangeConfiguration", { settings });
+    // Configure custom schemas
+    // -> Needs to be called before the server will process schemas
+    client.sendNotification("workspace/didChangeConfiguration", {
+      settings: {
+        yaml: {
+          schemas: customSchemas,
+        },
+      },
+    });
 
     //
-    // The message below don't work, it seems Nova is only exposing known/implemented requests
+    // The messages below don't work, it seems Nova is only exposing known/implemented requests
     //
 
     // const schemas = await fetchSchemaAssociations()

--- a/yaml.novaextension/README.md
+++ b/yaml.novaextension/README.md
@@ -58,6 +58,46 @@ For example, `.circleci/config.yml` or `.github/workflows/**.yml` have known sch
 
 To see all available schemas, visit [www.schemastore.org/json/](https://www.schemastore.org/json/).
 
+### Custom tags
+
+[YAML tags](https://yaml.org/spec/1.2/spec.html#id2761292)
+let you programatically control the parsing of values in YAML files during parsing.
+For example, a tag could be used to unpack a secret:
+
+```yaml
+passwordKey: !secret database.password
+```
+
+Yaml Extension needs to know about these tags so it can help with suggestions and error messages.
+You can define these globally or per-project inside of Nova.
+
+> **Note:** global and per-project custom tags are not merged.
+> If you have global tags you will need to duplicate them if you want per-project tags.
+
+Each line of the configuration should be a separate tag you want to add.
+It can optionally have a type too, which Yaml Extension will check the value of.
+
+The type can be either `scalar`, `mapping` or `sequence`,
+for more information, [look here](https://github.com/redhat-developer/yaml-language-server#adding-custom-tags).
+
+#### Global custom tags
+
+To set global custom-tags, go to **Extensions** → **Extension Library...**.
+Then navigate to **YAML** and then to the **Preferences** tab.
+
+#### Per-project custom tags
+
+To set per-project, navigate to your project settings by clicking your project name in the top left.
+Then go to **YAML** in the side bar and configure **Custom tags** there.
+
+#### Example custom tags
+
+```
+!secret scalar
+!automobile mapping
+!peopleList sequence
+```
+
 ### Under the hood
 
 Yaml Extension runs the [redhat-developer/yaml-language-server](http://github.com/redhat-developer/yaml-language-server) Language Server which

--- a/yaml.novaextension/extension.json
+++ b/yaml.novaextension/extension.json
@@ -30,5 +30,51 @@
         "title": "Reset Yaml Install Lock"
       }
     ]
-  }
+  },
+
+  "config": [
+    {
+      "key": "yaml.format.enable",
+      "title": "Format",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to format YAML documents or not"
+    },
+    {
+      "key": "yaml.validate",
+      "title": "Validate",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to validate YAML documents or not"
+    },
+    {
+      "key": "yaml.hover",
+      "title": "Hover",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to show on-hover toolips"
+    },
+    {
+      "key": "yaml.completion",
+      "title": "Completions",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether suggest completions"
+    },
+    {
+      "key": "yaml.customTags",
+      "title": "Custom tags",
+      "type": "stringArray",
+      "description": "A global set of custom tags that the parser will validate against, e.g. \"!secret scalar\".\n\nSee \"Custom tags\" in the readme for more."
+    }
+  ],
+
+  "configWorkspace": [
+    {
+      "key": "yaml.customTags",
+      "title": "Custom tags",
+      "type": "stringArray",
+      "description": "A set of custom tags that the parser will validate against, e.g. \"!secret scalar\".\n\nSee \"Custom tags\" in the readme for more."
+    }
+  ]
 }


### PR DESCRIPTION
- removed unused schema fetching code
- refactor k8s filenames to a function
- simplify LanguageClient creation
- only pass schemas to the language server
- add configuration to enable server features, rather than hard-coded
- add option for custom tags per-project or globally
- update readme