### PR TITLE
use recommended omit rather than only on npm install

### DIFF
--- a/src/Scripts/yaml-language-server.ts
+++ b/src/Scripts/yaml-language-server.ts
@@ -99,7 +99,7 @@ export class YamlLanguageServer {
     debug("#installPackages", installDir);
 
     const proc = new Process("/usr/bin/env", {
-      args: ["npm", "install", "--no-audit", "--only=production"],
+      args: ["npm", "install", "--no-audit", "--omit=dev"],
       cwd: installDir,
     });
     proc.onStdout((line) => debug("npm install: " + line));

--- a/yaml.novaextension/README.md
+++ b/yaml.novaextension/README.md
@@ -7,7 +7,7 @@ and validating against known JSON schemas, including Kubernetes resources.
 
 Yaml Extension requires some additional tools to be installed on your Mac:
 
-- [Node.js 16](https://nodejs.org) and NPM 6 or newer
+- [Node.js 16](https://nodejs.org) and NPM 7 or newer
   - Node.js is used to run [redhat-developer/yaml-language-server](http://github.com/redhat-developer/yaml-language-server)
   - NPM is used to install the server during extension installation
   - Older versions of Node.js and NPM should still work, but newer versions are advised.


### PR DESCRIPTION
This extension displays the below NPM warning, which makes it seem like something went wrong upon instantiating.

```
ERROR(npm install): npm WARN config only Use `--omit=dev` to omit dev dependencies from the install.
```

Although `--only` is still supported it's been deprecated and is no longer [documented](https://docs.npmjs.com/cli/v9/commands/npm-install?v=true) as of v7. This PR simply changes it to the now-recommended `--omit` flag. 

